### PR TITLE
fix(seo): Allow search engine indexing

### DIFF
--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -24,6 +24,17 @@ export async function generateMetadata({
       title: 'NumTrip - Directorio Verificado de Contactos Turísticos en Cartagena',
       description: 'Encuentra contactos verificados (teléfono, email, WhatsApp) de hoteles, tours y transporte en Cartagena, Colombia. Información turística confiable y actualizada.',
       keywords: 'turismo Cartagena, hoteles Cartagena, tours Cartagena, transporte Cartagena, contactos turísticos, directorio turístico, viajes Colombia',
+      robots: {
+        index: true,
+        follow: true,
+        googleBot: {
+          index: true,
+          follow: true,
+          'max-video-preview': -1,
+          'max-image-preview': 'large',
+          'max-snippet': -1,
+        },
+      },
       openGraph: {
         title: 'NumTrip - Directorio Verificado de Contactos Turísticos',
         description: 'Encuentra contactos verificados de hoteles, tours y transporte en Cartagena, Colombia.',
@@ -43,6 +54,17 @@ export async function generateMetadata({
       title: 'NumTrip - Verified Tourism Contact Directory in Cartagena',
       description: 'Find verified contacts (phone, email, WhatsApp) for hotels, tours and transportation in Cartagena, Colombia. Reliable and updated tourist information.',
       keywords: 'Cartagena tourism, Cartagena hotels, Cartagena tours, Cartagena transportation, tourist contacts, tourism directory, Colombia travel',
+      robots: {
+        index: true,
+        follow: true,
+        googleBot: {
+          index: true,
+          follow: true,
+          'max-video-preview': -1,
+          'max-image-preview': 'large',
+          'max-snippet': -1,
+        },
+      },
       openGraph: {
         title: 'NumTrip - Verified Tourism Contact Directory',
         description: 'Find verified contacts for hotels, tours and transportation in Cartagena, Colombia.',

--- a/apps/web/src/app/robots.txt/route.ts
+++ b/apps/web/src/app/robots.txt/route.ts
@@ -37,7 +37,6 @@ Disallow: /favicon.ico
 
 # Sitemaps
 Sitemap: https://numtrip.com/sitemap.xml
-Sitemap: https://numtrip.com/sitemap-index.xml
 
 # No crawl delay for important bots
 User-agent: Bingbot


### PR DESCRIPTION
This commit fixes a critical SEO issue that was preventing Google and other search engines from indexing the site.

The root cause was that the internationalization (i18n) layout file (`[locale]/layout.tsx`) was overriding the root layout's metadata but was not including the `robots` property. This resulted in pages not having the necessary "index, follow" directive for crawlers.

- Added `robots: { index: true, follow: true, ... }` to the metadata in `apps/web/src/app/[locale]/layout.tsx` to explicitly allow indexing for all localized pages.
- Removed a redundant sitemap URL from the `robots.txt` generator (`apps/web/src/app/robots.txt/route.ts`) for better configuration hygiene.